### PR TITLE
Fix for MAS issue 33313440

### DIFF
--- a/src/App/FileTransferPage.xaml.cs
+++ b/src/App/FileTransferPage.xaml.cs
@@ -214,6 +214,7 @@ namespace Microsoft.FactoryOrchestrator.UWP
             SendClientFileButton.IsEnabled = true;
             GetServerFileButton.IsEnabled = true;
             TranferRing.IsActive = false;
+            _ = sending ? SendClientFileButton.Focus(FocusState.Programmatic) : GetServerFileButton.Focus(FocusState.Programmatic);
         }
 
         private void ContainerCheckBox_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Fix for Bug 33313440: A11y_FactoryOrchestrator_TransferFileTab_SendLocalFile/folder_Keyboard : The keyboard focus order is incorrect after selecting the confirm file copy button.